### PR TITLE
Update Dockerfile to install MySQL Client successfully

### DIFF
--- a/webapp/go/Dockerfile
+++ b/webapp/go/Dockerfile
@@ -1,4 +1,4 @@
 FROM golang:1.11
 
-RUN apt-get update && apt-get -y install mysql-client
+RUN apt-get update && apt-get -y install default-mysql-client
 RUN curl -sL https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 > /usr/bin/dep && chmod +x /usr/bin/dep


### PR DESCRIPTION
aptでインストールできるMySQL Clientの名前が `mysql-client` から `default-mysql-client` に変わったため、Dockerを動かすためにはこちらの修正が必要でした。